### PR TITLE
Add support for specifying an address when generating blocks

### DIFF
--- a/routes/1.js
+++ b/routes/1.js
@@ -234,11 +234,14 @@ module.exports = function (router, callback) {
   }
 
   router.post('/r/generate', authMiddleware, (req, res) => {
-    rpc('getnewaddress', [], (err, address) => {
-      if (err) return res.easy(err)
-
-      rpc('generatetoaddress', [parseInt(req.query.count) || 1, address], res.easy)
-    })
+    if (req.query.address) {
+      rpc('generatetoaddress', [parseInt(req.query.count) || 1, req.query.address], res.easy)
+    } else {
+      rpc('getnewaddress', [], (err, address) => {
+        if (err) return res.easy(err)
+        rpc('generatetoaddress', [parseInt(req.query.count) || 1, address], res.easy)
+      })
+    }
   })
 
   router.post('/r/faucet', authMiddleware, (req, res) => {


### PR DESCRIPTION
Allow an optional `address` parameter to the `/r/generate` endpoint, so we don't always generate a new one:

`curl -X POST "http://localhost:8081/1/r/generate?count=10&key=satoshi&address=bcrt1qcn9c23mwchxvy3hz2fss7slecsc0gmj30g9zpx"`