### PR TITLE
Fix typo RPCCOOKIE causing the regtest to stop working with RPC cookie authentication via the Docker setup

### DIFF
--- a/rpc.js
+++ b/rpc.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 let auth;
 
-if (process.env.RPCOOKIE) {
+if (process.env.RPCCOOKIE) {
   try {
     auth = fs.readFileSync(process.env.RPCCOOKIE);
   } catch (e) {
@@ -14,7 +14,7 @@ if (process.env.RPCAUTH) {
 }
 
 if (!auth) {
-  console.log(`RPCAUTH or RPCOOKIE must be specified`);
+  console.log(`RPCAUTH or RPCCOOKIE must be specified`);
 }
 
 module.exports = require('yajrpc/qup')({


### PR DESCRIPTION
It fixes the regression that was introduced by https://github.com/bitcoinjs/regtest-server/commit/46b85c413b5f4171eb3e96ee208834c77915dc66